### PR TITLE
Add debug output and improve citation handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ public_html/index.php
 public_html/web.config.1
 public_html/mw/LocalSettings.php
 public_html/new_html/jsons_data/*.json
+public_html/new_html/tests/text.php

--- a/public_html/new_html/WikiText/WikiParse/Citations.php
+++ b/public_html/new_html/WikiText/WikiParse/Citations.php
@@ -73,7 +73,7 @@ function get_full_refs($text)
 
 function getShortCitations($text)
 {
-    preg_match_all("/<ref([^\/>]*?)\/\s*>/is", $text, $matches);
+    preg_match_all("/<ref ([^\/>]*?)\/\s*>/is", $text, $matches);
     // ---
     $citations = [];
     // ---

--- a/public_html/new_html/WikiText/fixes/expend_refs.php
+++ b/public_html/new_html/WikiText/fixes/expend_refs.php
@@ -17,25 +17,36 @@ function refs_expend_work($first, $alltext)
     if (empty($alltext)) {
         $alltext = $first;
     }
+
+    test_print("refs_expend_work: \n");
+
     $allpage_fullrefs = get_full_refs($alltext);
 
     $lead_fullrefs = get_full_refs($first);
     $lead_short_refs = getShortCitations($first);
-
+    // ---
+    test_print(var_export($lead_short_refs, true));
+    // ---
     foreach ($lead_short_refs as $cite) {
-        $name = $cite["name"];
-        $refe = $cite["tag"];
+        // ---
+        $name = $cite["name"] ?? '';
+        $refe = $cite["tag"] ?? '';
+        // ---
+        if (empty($name) || empty($refe)) {
+            continue;
+        }
         // ---
         if (isset($lead_fullrefs[$name])) {
             continue;
         }
         // ---
-        $rr = $allpage_fullrefs[$name] ?? false;
+        $rr = $allpage_fullrefs[$name] ?? "";
         // ---
-        if ($rr) {
+        if (!empty($rr)) {
+            test_print("refs_expend_work: name:($name), refe:($refe), rr:($rr)\n");
             $first = str_replace($refe, $rr, $first);
         }
-        // ---
     }
+    // ---
     return $first;
 }

--- a/public_html/new_html/WikiText/index.php
+++ b/public_html/new_html/WikiText/index.php
@@ -86,7 +86,10 @@ function get_wikitext($title, $all)
     // ---
     if ($source != '') {
         // ---
+        test_print("source is not empty\n");
+        // ---
         if ($all == '') {
+            test_print("get_lead_section: \n");
             $source = get_lead_section($source);
         }
         // ---

--- a/public_html/new_html/WikiText/lead_section.php
+++ b/public_html/new_html/WikiText/lead_section.php
@@ -22,6 +22,7 @@ function get_lead_section($wikitext)
     }
 
     $lead .= "\n==References==\n<references />";
+
     $lead = refs_expend_work($lead, $wikitext);
 
     return $lead;

--- a/public_html/new_html/html_to_Segments.php
+++ b/public_html/new_html/html_to_Segments.php
@@ -57,10 +57,12 @@ function do_html_to_seg($text)
 function html_to_seg($text, $file_seg)
 {
     // ---
-    $seg_text = read_file($file_seg);
-    // ---
-    if ($seg_text != '') {
-        return $seg_text;
+    if (!isset($_GET['new'])) {
+        $seg_text = read_file($file_seg);
+        // ---
+        if ($seg_text != '') {
+            return $seg_text;
+        }
     }
     // ---
     $result = do_html_to_seg($text);

--- a/public_html/new_html/require.php
+++ b/public_html/new_html/require.php
@@ -7,7 +7,7 @@ if (isset($_GET['test'])) {
 }
 function test_print($str)
 {
-    if (isset($_GET['test'])) {
+    if (isset($_GET['test']) || defined('DEBUGX')) {
         echo $str;
         echo "\n";
     }

--- a/public_html/new_html/wikitext_to_html.php
+++ b/public_html/new_html/wikitext_to_html.php
@@ -71,9 +71,12 @@ function do_wiki_text_to_html($wikitext, $title)
 function wiki_text_to_html($wikitext, $file_html, $title)
 {
     // ---
-    $text = read_file($file_html);
-    // ---
-    if ($text != '') return $text;
+    if (!isset($_GET['new'])) {
+        // ---
+        $text = read_file($file_html);
+        // ---
+        if ($text != '') return $text;
+    }
     // ---
     if ($wikitext == '') return "";
     // ---


### PR DESCRIPTION
Added additional test_print debug statements throughout WikiText processing functions to aid in debugging. Improved robustness in expend_refs.php by handling missing citation names or tags and ensuring only non-empty references are replaced. Updated .gitignore to exclude test file. Adjusted regex in Citations.php for more accurate short citation matching. test_print now also works when DEBUGX is defined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved citation matching by requiring a space after the `<ref` tag in short citation recognition.

* **Style**
  * Added a blank line for improved readability in the references section markup.

* **Chores**
  * Updated `.gitignore` to exclude a specific test PHP file from version control.

* **New Features**
  * Enhanced debug output throughout the reference expansion and wikitext processing, with more detailed tracing and broader conditions for displaying debug information.
  * Added ability to bypass cached content and force regeneration of segments and HTML via URL parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->